### PR TITLE
Fix Readme self-hosted file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You have a few options (choose one of these):
 
 ```html
 <!-- Host yourself -->
-<script type="module" src="sparky-text.js"></script>
+<script type="module" src="sparkly-text.js"></script>
 ```
 
 ```html

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You have a few options (choose one of these):
 
 ```html
 <!-- Host yourself -->
-<script type="module" src="table-saw.js"></script>
+<script type="module" src="sparky-text.js"></script>
 ```
 
 ```html


### PR DESCRIPTION
This PR fixes a boilerplate reference for the file name in the self hosted example.