### PR TITLE
add rainbow color

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,14 @@
           Incorrect sparkle attribute
         </sparkly-text>
       </p>
+      <p>
+        <sparkly-text
+          number-of-sparkles="5"
+          style="--sparkly-text-color: rainbow"
+        >
+          Rainbow sparkle attribute
+        </sparkly-text>
+      </p>
     </main>
   </body>
 </html>

--- a/sparkly-text.js
+++ b/sparkly-text.js
@@ -36,10 +36,24 @@ class SparklyText extends HTMLElement {
       svg {
         animation: sparkle-spin var(--_sparkle-base-animation-length) linear infinite;
       }
+
+      svg.rainbow path {
+        animation: rainbow-colors calc(var(--_sparkle-base-animation-length) * 2) linear infinite;
+      }
     }
 
     svg path {
       fill: var(--_sparkle-base-color);
+    }
+
+    @keyframes rainbow-colors {
+      0%, 100% { fill: #ff0000; }
+      14% { fill: #ff8000; }
+      28% { fill: #ffff00; }
+      42% { fill: #00ff00; }
+      56% { fill: #0000ff; }
+      70% { fill: #4b0082; }
+      84% { fill: #8f00ff; }
     }
 
     @keyframes sparkle-spin {
@@ -144,6 +158,13 @@ class SparklyText extends HTMLElement {
     }
 
     const sparkleWrapper = sparkleTemplate.cloneNode(true);
+    
+    // Add rainbow class if --sparkly-text-color is set to 'rainbow'
+    const styles = getComputedStyle(this);
+    if (styles.getPropertyValue('--sparkly-text-color').trim() === 'rainbow') {
+      sparkleWrapper.classList.add('rainbow');
+    }
+    
     update(sparkleWrapper);
     this.shadowRoot.appendChild(sparkleWrapper);
     sparkleWrapper.addEventListener("animationiteration", () => {


### PR DESCRIPTION
# Add Rainbow Sparkles Support

This PR adds support for rainbow-colored sparkles by allowing `rainbow` as a value for the `--sparkly-text-color` CSS custom property.

## Implementation Details

Added support for rainbow-colored sparkles through:
- New `rainbow-colors` keyframe animation that cycles through the rainbow spectrum
- Detection of `--sparkly-text-color: rainbow` to trigger rainbow mode
- Smooth color transitions through 7 colors (red, orange, yellow, green, blue, indigo, violet)
- Animation duration tied to existing `--sparkly-text-animation-length` property

## Usage

```html
<!-- Basic rainbow sparkles -->
<sparkly-text style="--sparkly-text-color: rainbow">
Rainbow sparkles!
</sparkly-text>

<!-- Customized rainbow sparkles -->
<sparkly-text
style="--sparkly-text-color: rainbow; --sparkly-text-animation-length: 3s"
number-of-sparkles="5">
Slower rainbow sparkles!
</sparkly-text>
```

The implementation preserves all existing functionality and respects user motion preferences through the `prefers-reduced-motion` media query.

## Testing

- Verified rainbow animation works in Chrome, Firefox, and Safari
- Confirmed smooth color transitions
- Tested with different animation durations
- Ensured backwards compatibility with single-color sparkles
