### PR TITLE
fix render bug when navigating

### DIFF
--- a/sparkly-text.js
+++ b/sparkly-text.js
@@ -118,14 +118,41 @@ class SparklyText extends HTMLElement {
       if (Number.isNaN(this.#numberOfSparkles)) {
         throw new Error(`Invalid number-of-sparkles value`);
       }
+      this.cleanupSparkles();
       this.addSparkles();
     }
 
     motionOK.addEventListener("change", this.motionOkChange);
+    window.addEventListener("popstate", this.handleNavigation);
+    window.addEventListener("pageshow", this.handlePageShow);
   }
 
   disconnectedCallback() {
     motionOK.removeEventListener("change", this.motionOkChange);
+    window.removeEventListener("popstate", this.handleNavigation);
+    window.removeEventListener("pageshow", this.handlePageShow);
+    this.cleanupSparkles();
+  }
+
+  handleNavigation = () => {
+    if (motionOK.matches) {
+      this.cleanupSparkles();
+      this.addSparkles();
+    }
+  };
+
+  handlePageShow = (event) => {
+    // If the page is being loaded from the bfcache
+    if (event.persisted && motionOK.matches) {
+      this.cleanupSparkles();
+      this.addSparkles();
+    }
+  };
+
+  cleanupSparkles() {
+    // Remove all existing sparkle SVGs
+    const sparkles = this.shadowRoot.querySelectorAll('svg');
+    sparkles.forEach(sparkle => sparkle.remove());
   }
 
   // Declare as an arrow function to get the appropriate 'this'


### PR DESCRIPTION
# Fix sparkly-text navigation and reload issues

## Problem
When navigating between subdomains and back to the main site the sparkly-text effect would render incorrectly, pulsing a single color and not randomizing position of the sparkles. This was due to the component not properly handling page navigation events and cleanup.

## Solution
Added proper event handlers for navigation and page show events, along with a cleanup method to ensure sparkles are properly reinitialized when needed.

### Changes
1. Added `cleanupSparkles()` method to remove existing sparkle SVGs
2. Added `handleNavigation` event handler for popstate events
3. Added `handlePageShow` event handler for bfcache loads
4. Added proper event listener cleanup in `disconnectedCallback`
5. Added cleanup before adding new sparkles in `connectedCallback`

### Code Changes
```js
// Added new methods
handleNavigation = () => {
  if (motionOK.matches) {
    this.cleanupSparkles();
    this.addSparkles();
  }
};

handlePageShow = (event) => {
  // If the page is being loaded from the bfcache
  if (event.persisted && motionOK.matches) {
    this.cleanupSparkles();
    this.addSparkles();
  }
};

cleanupSparkles() {
  // Remove all existing sparkle SVGs
  const sparkles = this.shadowRoot.querySelectorAll('svg');
  sparkles.forEach(sparkle => sparkle.remove());
}

// Modified connectedCallback to add event listeners

connectedCallback() {
  // ... existing code ...
  window.addEventListener("popstate", this.handleNavigation);
  window.addEventListener("pageshow", this.handlePageShow);
}

// Modified disconnectedCallback to cleanup

disconnectedCallback() {
  motionOK.removeEventListener("change", this.motionOkChange);
  window.removeEventListener("popstate", this.handleNavigation);
  window.removeEventListener("pageshow", this.handlePageShow);
  this.cleanupSparkles();
}
```

## Testing
1. Navigate to YOURSITE.com
2. Click any subdomain link (e.g., something.YOURSITE.com)
3. Use browser back button to return to YOURSITE.com
4. Verify sparkly text effect renders correctly
5. Refresh the page
6. Verify sparkly text effect still renders correctly

## Notes
- No changes to the core sparkle animation logic
- Added proper cleanup to prevent memory leaks
- Maintains existing motion preference checks